### PR TITLE
Remove babelrc from node module

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 src/
 test/
 benchmark.js
+.babelrc


### PR DESCRIPTION
The presence of .babelrc in the npm package causes issues if you use this library within a project that uses babel. This file gets read as a local configuration.