### PR TITLE
forloop with new declaration words fix

### DIFF
--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -167,7 +167,7 @@ const rules = {
 };
 
 const regexString = [];
-for (let k in rules) {
+for (let k of rules) {
   const { re } = rules[k];
   regexString.push(`(${re.source})`);
 }


### PR DESCRIPTION
'of' instead of 'in' must be used with new declaration words 'let' and 'const'. This code actually breaks ie11.